### PR TITLE
Make baseUrl parameter mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 ### Added
-- Added new `changeBaseUrl` method to change the baseUrl.
-### Changed
 - None.
+### Changed
+- Allowed to change the baseUrl.
 ### Deprecated
 - None.
 ### Removed

--- a/Sources/Microya/Core/ApiProvider.swift
+++ b/Sources/Microya/Core/ApiProvider.swift
@@ -17,7 +17,7 @@ open class ApiProvider<EndpointType: Endpoint> {
   public let plugins: [Plugin<EndpointType>]
 
   /// The common base URL of the API endpoints.
-  public private(set) var baseUrl: URL
+  public var baseUrl: URL
 
   /// The mocking behavior of the provider. Set this to receive mocked data in your tests. Use `nil` to make actual requests to your server (the default).
   public let mockingBehavior: MockingBehavior<EndpointType>?
@@ -288,11 +288,6 @@ open class ApiProvider<EndpointType: Endpoint> {
     dispatchGroup.wait()
 
     return result!
-  }
-
-  /// Change the baseUrl
-  public func changeBaseUrl(_ url: URL) {
-    baseUrl = url
   }
 
   private func decodeBody<ResultType: Decodable>(


### PR DESCRIPTION
## Proposed Changes

  - Allows to change the baseUrl of `ApiProvider`.